### PR TITLE
Travis CI and Clang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libpfc"]
 	path = libpfc
-	url = https://github.com/travisdowns/libpfc
+	url = https://github.com/obilaniu/libpfc
 [submodule "nasm-utils"]
 	path = nasm-utils
 	url = https://github.com/travisdowns/nasm-utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,17 @@ matrix:
           - gcc-6
           - g++-6
           - nasm
+    - env: C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0
+      addons:
+        apt:
+          sources:
+          - llvm-toolchain-trusty-6.0
+          - ubuntu-toolchain-r-test
+          packages:
+          - clang-6.0
+          - clang++-6.0
+          - nasm
 
 script:
-- make CC=${C_COMPILER} CXX=${CXX_COMPILER} USE_LIBPFC=0
+- make CC=${C_COMPILER} CXX=${CXX_COMPILER} USE_LIBPFC=0 -j
 - ./uarch-bench --test-name=default/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+sudo: false
+branches:
+  except:
+    - /^(wip\/)?(appveyor|msvc|mingw|windows)(\-.+)?$/
+
+matrix:
+  include:
+    - env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-6
+          - g++-6
+          - nasm
+
+script:
+- make CC=${C_COMPILER} CXX=${CXX_COMPILER} USE_LIBPFC=0
+- ./uarch-bench --test-name=default/*


### PR DESCRIPTION
This should get clang working, which requires an update to libpfc; I've switched over to the official repo, but just pulling the latest changes into travisdowns/libpfc and updating the submodule would work too.

Also adds Travis CI builds for both GCC and Clang, though you'll need to register for Travis CI to get the builds going.