### PR TITLE
switch to /usr/bin/env in shebang lines for increased portability

### DIFF
--- a/scripts/l2-bandwidth/plot-all.sh
+++ b/scripts/l2-bandwidth/plot-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # Creates the plots used in https://github.com/travisdowns/uarch-bench/wiki/Getting-everything-the-L2-has-to-give
 

--- a/scripts/l2-bandwidth/run-all.sh
+++ b/scripts/l2-bandwidth/run-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # runs all the tests needed for the l2 max bandwidth investigation at
 # https://github.com/travisdowns/uarch-bench/wiki/Maxing-out-the-L2-cache

--- a/scripts/nop-iterator.sh
+++ b/scripts/nop-iterator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 
 # Recompiles and runs uarch-bench repeatedly, varying the value of a given nasm define (defaulting to NOPCOUNT)

--- a/uarch-bench.sh
+++ b/uarch-bench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+# !/usr/bin/env bash
 # launches the uarch-bench process after trying to disable turbo
 # Some parts based on http://notepad2.blogspot.com/2014/11/a-script-to-turn-off-intel-cpu-turbo.html
 


### PR DESCRIPTION
/usr/bin/env is more standard than /bin/bash. In particular, my motivating use case is running on the NixOS linux distro, which explicitly lacks /bin/bash.